### PR TITLE
GEMM compatibility with cl2.hpp

### DIFF
--- a/GEMM/CHANGELOG
+++ b/GEMM/CHANGELOG
@@ -2,6 +2,11 @@
 
 This file contains all changes made to the source code for each release.
 
+## 1.3
+
+## Added:
+- Support for cl2.hpp header file by removing hard links to cl.hpp
+
 ## 1.2
 
 ## Added:

--- a/GEMM/CMakeLists.txt
+++ b/GEMM/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.13)
-project(GEMM VERSION 1.2)
+project(GEMM VERSION 1.3)
 
 set(KERNEL_NAME gemm CACHE STRING "Name of the OpenCL kernel")
 set(DEFAULT_MATRIX_SIZE 8 CACHE STRING "Default size of the used matrices")

--- a/GEMM/src/host/execution.h
+++ b/GEMM/src/host/execution.h
@@ -26,9 +26,6 @@ SOFTWARE.
 #include <memory>
 #include <vector>
 
-/* External library headers */
-#include "CL/cl.hpp"
-
 #include "parameters.h"
 #include "gemm_benchmark.hpp"
 

--- a/GEMM/src/host/execution_default.cpp
+++ b/GEMM/src/host/execution_default.cpp
@@ -30,7 +30,6 @@ SOFTWARE.
 #include <vector>
 
 /* External library headers */
-#include "CL/cl.hpp"
 #ifdef INTEL_FPGA
 #include "CL/cl_ext_intelfpga.h"
 #endif
@@ -215,7 +214,7 @@ calculate(hpcc_base::ExecutionSettings<gemm::GEMMProgramSettings> const& config,
 #endif
         auto t1 = std::chrono::high_resolution_clock::now();
         for (int i=0; i < config.programSettings->kernelReplications; i++) {
-            compute_queues[i].enqueueTask(gemmkernels[i]);
+            compute_queues[i].enqueueNDRangeKernel(gemmkernels[i], cl::NullRange, cl::NDRange(1));
         }
         for (int i=0; i < config.programSettings->kernelReplications; i++) {
             compute_queues[i].finish();


### PR DESCRIPTION
Remove old cl.hpp header from GEMM host code and adjust kernel calls.