### PR TITLE
add config for b_eff u280 PCIE benchmark using HBM

### DIFF
--- a/b_eff/.gitignore
+++ b/b_eff/.gitignore
@@ -1,3 +1,4 @@
 # Exclude cmake build folder and CLion files
 cmake-build*
+build*
 .idea

--- a/b_eff/configs/Xilinx_U280_HBM.cmake
+++ b/b_eff/configs/Xilinx_U280_HBM.cmake
@@ -1,0 +1,14 @@
+
+set(USE_MPI Yes CACHE BOOL "" FORCE)
+set(USE_SVM No CACHE BOOL "" FORCE)
+set(USE_HBM No CACHE BOOL "" FORCE)
+set(FPGA_BOARD_NAME "xilinx_u280_gen3x16_xdma_1_202211_1" CACHE STRING "" FORCE)
+set(XILINX_LINK_SETTINGS_FILE ${CMAKE_SOURCE_DIR}/settings/settings.link.xilinx.u280.hbm.ini CACHE FILEPATH "" FORCE)
+set(XILINX_COMPILE_SETTINGS_FILE ${CMAKE_SOURCE_DIR}/settings/settings.compile.xilinx.u280.ini CACHE FILEPATH "" FORCE)
+
+# STREAM specific options
+# Defaults to a total of ~12GB data
+set(CHANNEL_WIDTH 0 CACHE STRING "Width of a single external channel in Byte will not be considered" FORCE)
+set(NUM_REPLICATIONS 2 CACHE STRING "Number of kernel replications will not be considered" FORCE)
+
+set(USE_DEPRECATED_HPP_HEADER Yes CACHE BOOL "Use cl.hpp intead of cl2.hpp" FORCE)

--- a/b_eff/scripts/run_u280_pcie_hbm.sh
+++ b/b_eff/scripts/run_u280_pcie_hbm.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+#
+# Run the b_eff kernel for the u280 board using HBM over PCIE.
+# This is an example script, how the synthesis can be started on Noctua using a HPCC FPGA configuration file.
+# Submit this script from the benchmark folder!
+#
+#SBATCH -p fpga
+#SBATCH --constraint=xilinx_u280_xrt2.14
+#SBATCH -t 2:00:00
+#SBATCH --mem=10g
+#SBATCH -o beff_pcie_n2-%j.out
+#SBATCH -e beff_pcie_n2-%j.out
+#SBATCH -n 2
+#SBATCH -N 1
+
+module reset
+module load devel toolchain lib fpga foss Boost xilinx/xrt/2.14 changeFPGAlinks CMake
+
+srun -n 2 build_u280_pcie_hbm/bin/Network_xilinx -f build_u280_pcie_hbm/bin/communication_PCIE.xclbin --comm-type PCIE

--- a/b_eff/settings/settings.link.xilinx.u280.hbm.ini
+++ b/b_eff/settings/settings.link.xilinx.u280.hbm.ini
@@ -1,0 +1,4 @@
+[connectivity]
+nk=dummyKernel:1:dummyKernel
+
+sp=dummyKernel.m_axi_gmem:HBM[0]


### PR DESCRIPTION
This benchmark measures the PCIE latency using HBM and not DDR.